### PR TITLE
Delay OSE in definition contexts until pass 2

### DIFF
--- a/expander.rkt
+++ b/expander.rkt
@@ -216,6 +216,19 @@
 ;;            collected regardless of success or failure
 (struct match-result [penv progress ose-stxs] #:transparent)
 
+;; An OSEError is a (ose-error Symbol String Stx (or Stx #f) (Listof Stx))
+;; A stx-error for a macro call that matched no clause, carrying the ~var-tagged
+;; subexpressions whose optimistic expansion has not happened yet.
+;;
+;; The expansion is left to whoever catches the error, because only the catcher
+;; knows when it is safe to run: in an expression context that is immediately, but
+;; in a definition context pass 1 has not yet discovered every binding, so it must
+;; wait until pass 2. The catcher expands them in the scope it passed to
+;; expand-macro, which is by construction the scope the match was attempted in.
+;;
+;; exprs : (Listof Stx) — subexpressions awaiting optimistic expansion
+(struct ose-error stx-error [exprs] #:transparent)
+
 ;; match-result-success? : MatchResult -> Boolean
 (define (match-result-success? r)
   (and (match-result-penv r) #t))
@@ -343,11 +356,16 @@
             [_ (raise-and-record-stx-error (stx-error 'let-syntax "bad syntax" expr #f))]))]
        ;; macro application
        [(macro-binding? binding)
-        ;; NOTE: expand-macro may perform optimistic subexpression expansion as a side effect before
-        ;; raising a stx-error
-        (with-stx-error-handling
-          (define-values (marked-stx disjoined-scp) (expand-macro head-stx expr scp))
-          (expand-expr marked-stx disjoined-scp))]
+        ;; NOTE: when no clause matches, expand-macro raises an ose-error carrying
+        ;; subexpressions to optimistically expand. This is an expression context, so
+        ;; every binding is already known and they can be expanded right away.
+        (define result
+          (with-stx-error-handling
+            (define-values (marked-stx disjoined-scp) (expand-macro head-stx expr scp))
+            (expand-expr marked-stx disjoined-scp)))
+        (when (ose-error? result)
+          (for ([e (ose-error-exprs result)]) (expand-expr e scp)))
+        result]
        ;; unbound in head position - pass through the stx-error from scope-resolve
        [(stx-error? binding)
         binding]
@@ -429,6 +447,10 @@
              `(#%expression ,expr-stx)]
             [_ (raise-and-record-stx-error (stx-error '#%expression "bad syntax" def #f))]))]
        ;; macro application
+       ;; NOTE: when no clause matches, expand-macro raises an ose-error. Its
+       ;; subexpressions are NOT expanded here — pass 1 has not discovered every
+       ;; binding yet, so expanding now would resolve them against an incomplete
+       ;; scope. The error is returned as this def's Pass1Def and pass 2 expands them.
        [(macro-binding? binding)
         (with-stx-error-handling
           (define-values (marked-stx disjoined-scp) (expand-macro head-stx def scp))
@@ -448,6 +470,11 @@
 ;; override it with their stored disjoin scope.
 (define (expand-def-pass2 def scp)
   (match def
+    ;; an unmatched macro call from pass 1: now that every binding in this
+    ;; definition context is known, optimistically expand its subexpressions
+    [(? ose-error?)
+     (for ([e (ose-error-exprs def)]) (expand-expr e scp))
+     def]
     [(? stx-error?) def]  ; pass through errors from pass 1
     [`(define ,var ,expr)
      `(define ,var ,(expand-expr expr scp))]
@@ -475,7 +502,7 @@
   (define binding (scope-resolve use-scp mname))
   (match-define (macro-binding _ macrot def-scp) binding)
   (define-values (penv tmpl)
-    (select-syntax-rule who macrot expr use-scp))
+    (select-syntax-rule who macrot expr))
   (define def-mark (fresh-def-mark))
   (define expanded-tmpl (expand-template tmpl penv def-mark))
   (define introduced-defn-scp (new-scope def-scp))
@@ -653,22 +680,23 @@
 ;; Syntax-Rules Matching
 ;; ============================================================
 
-;; select-syntax-rule : Symbol Syntax Syntax Scope -> (values PatternEnv Syntax)
+;; select-syntax-rule : Symbol Syntax Syntax -> (values PatternEnv Syntax)
 ;; Selects the first matching clause from a syntax-rules transformer.
-;; On failure, OSE-expands ~var subexpressions from the best-progress clause(s), then raises.
-(define (select-syntax-rule who macrot expr scp)
+;; On failure, raises an ose-error carrying the ~var subexpressions to expand.
+(define (select-syntax-rule who macrot expr)
   ;; macrot is (syntax-rules (literal ...) clause ...)
   (match macrot
     [(stx-quote (,_syntax-rules (,literal-ids ...) ,clauses ...))
      (define is-datum-literal? (make-is-datum-literal? literal-ids))
-     (try-patterns who clauses expr is-datum-literal? scp)]))
+     (try-patterns who clauses expr is-datum-literal?)]))
 
-;; try-patterns : Symbol [Listof Clause] Syntax (Id -> Bool) Scope -> (values PatternEnv Syntax)
+;; try-patterns : Symbol [Listof Clause] Syntax (Id -> Bool) -> (values PatternEnv Syntax)
 ;; Tries each clause in order until one matches.
 ;; On success, returns (values penv tmpl).
-;; On failure, OSE-expands ~var subexpressions from the best-progress clause(s), then raises.
+;; On failure, raises an ose-error carrying the ~var subexpressions of the
+;; best-progress clause(s), leaving their optimistic expansion to the catcher.
 ;; A Clause is (List pattern template).
-(define (try-patterns who clauses expr is-datum-literal? scp)
+(define (try-patterns who clauses expr is-datum-literal?)
   (define results+tmpls
     (for/list ([clause clauses])
       (match clause
@@ -685,19 +713,19 @@
              (lambda (a b)
                (progress<? (match-result-progress (car a))
                            (match-result-progress (car b))))))
-     (when (pair? sorted)
-       (define best-progress (match-result-progress (car (last sorted))))
-       (define r+t-with-best-progress
-         (for/list ([r+t sorted]
-                    #:when (equal? (match-result-progress (car r+t)) best-progress))
-           r+t))
-       (define oses
-         (apply set-intersect
-                (for/list ([r+t r+t-with-best-progress])
-                  (match-result-ose-stxs (car r+t)))))
-       (for ([e oses])
-         (expand-expr e scp)))
-     (raise-and-record-stx-error (stx-error who "no pattern matched" expr #f))]))
+     (define oses
+       (cond
+         [(pair? sorted)
+          (define best-progress (match-result-progress (car (last sorted))))
+          (define r+t-with-best-progress
+            (for/list ([r+t sorted]
+                       #:when (equal? (match-result-progress (car r+t)) best-progress))
+              r+t))
+          (apply set-intersect
+                 (for/list ([r+t r+t-with-best-progress])
+                   (match-result-ose-stxs (car r+t))))]
+         [else '()]))
+     (raise-and-record-stx-error (ose-error who "no pattern matched" expr #f oses))]))
 
 ;; progress<? : Progress Progress -> Boolean
 ;; True if p1 represents less progress than p2.
@@ -1570,6 +1598,19 @@
        (my-let ([x 1]) x)))
    (define result (analyze! (list (sexpr->syntax sexp))))
    (check-equal? (expander-result-errors result) (list)))
+  (test-case
+   "delayed OSE in a definition context is reported exactly once"
+   ;; The failing match is recorded when it is raised in pass 1; running the
+   ;; carried subexpressions in pass 2 must not record a second diagnostic.
+   (define sexp
+     '(block
+       (define-syntax m
+         (syntax-rules ()
+           [(m 1 (~var e expr)) 1]))
+       (m 2 (let ([q 1]) q))
+       (define x 2)))
+   (define result (analyze! (list (sexpr->syntax sexp))))
+   (check-equal? (length (expander-result-errors result)) 1))
 
   ;; ----------------------------------------
   ;; Ellipsis tests

--- a/lsp-tests.rkt
+++ b/lsp-tests.rkt
@@ -1533,6 +1533,55 @@
     (list (hash 'uri test-uri 'range (find-range source "q2" 0)))))
 
   ;; ============================================================
+  ;; OSE in definition contexts (delayed until pass 2)
+  ;; ============================================================
+
+  (test-case
+   "optimistic sub-expression expansion: def context sees later bindings"
+   ;; m is applied in a definition context, so it expands during pass 1 — before
+   ;; (define x 2) has been discovered. Its OSE must be delayed until pass 2 so
+   ;; that autocomplete at the ~var subexpression still sees x.
+   (define source
+     "(define-syntax m
+        (syntax-rules ()
+          [(m 1 (~var e expr)) 1]))
+      (m 2 HERE)
+      (define x 2)")
+   (check-equal?
+    (autocomplete source (find-position source "HERE"))
+    (list (hasheq 'label "m") (hasheq 'label "x"))))
+
+  (test-case
+   "optimistic sub-expression expansion: def context, nested macro expansion"
+   ;; outer expands to an inner use during pass 1, and inner fails to match.
+   ;; The delayed OSE must run in the disjoin scope created for outer's expansion,
+   ;; and must still see the later (define x 2).
+   (define source
+     "(define-syntax inner
+        (syntax-rules ()
+          [(inner 1 (~var e expr)) 1]))
+      (define-syntax outer
+        (syntax-rules ()
+          [(outer e) (inner 2 e)]))
+      (outer HERE)
+      (define x 2)")
+   (check-equal?
+    (autocomplete source (find-position source "HERE"))
+    (list (hasheq 'label "inner") (hasheq 'label "outer") (hasheq 'label "x"))))
+
+  (test-case
+   "optimistic sub-expression expansion: def context OSE still resolves references"
+   ;; The delayed OSE expansion records resolutions just like an eager one would.
+   (define source
+     "(define-syntax m
+        (syntax-rules ()
+          [(m 1 (~var e expr)) 1]))
+      (m 2 (let ([q 1]) q))")
+   (check-equal?
+    (goto-definition source (find-position source "q" 1))
+    (list (hash 'uri test-uri 'range (find-range source "q" 0)))))
+
+  ;; ============================================================
   ;; Ellipsis error cases
   ;; ============================================================
 


### PR DESCRIPTION
## Summary

When a macro fails to match in a definition context, its optimistic sub-expression (OSE) expansion is now delayed until pass 2, after all bindings in the definition context have been discovered. This ensures that OSE'd subexpressions can resolve references to bindings defined later in the same definition context.

## Changes

- **New `ose-error` struct**: Extends `stx-error` to carry a list of subexpressions awaiting optimistic expansion, deferring their expansion to the caller who knows when it's safe to run.

- **Expression context handling**: In `expand-expr`, when a macro application raises an `ose-error`, the subexpressions are expanded immediately (in the same scope as the failed match) since all bindings are already known in expression contexts.

- **Definition context handling**: In `expand-def-pass1`, `ose-error`s are returned as-is without expanding their subexpressions, since pass 1 hasn't yet discovered all bindings. In `expand-def-pass2`, the delayed subexpressions are now expanded in the appropriate scope.

- **Pattern matching refactor**: `select-syntax-rule` and `try-patterns` no longer take a `scp` parameter or perform OSE expansion themselves. Instead, they raise an `ose-error` carrying the subexpressions, leaving expansion to the caller.

- **Test coverage**: Added tests verifying that delayed OSE in definition contexts:
  - Sees bindings defined later in the same context
  - Works with nested macro expansion
  - Still records reference resolutions correctly
  - Reports errors exactly once (not duplicated when pass 2 runs)

## Implementation Details

The key insight is that OSE expansion safety depends on context:
- **Expression context**: Safe to expand immediately since the scope is complete
- **Definition context pass 1**: Unsafe—bindings haven't been discovered yet
- **Definition context pass 2**: Safe—all bindings are now known

By deferring the decision to the caller via `ose-error`, the expander lets each context handle OSE at the right time, enabling IDE features like autocomplete to see bindings defined later in the same definition context.

https://claude.ai/code/session_0197toUbr8UfpNRYpv8kDBDW